### PR TITLE
Error messages in JSON format instead of string and disabled RestAuthenticationEntryPoint for now

### DIFF
--- a/zuulgateway/src/main/java/com/advertisementproject/zuulgateway/api/exceptions/RestAuthenticationEntryPoint.java
+++ b/zuulgateway/src/main/java/com/advertisementproject/zuulgateway/api/exceptions/RestAuthenticationEntryPoint.java
@@ -1,9 +1,8 @@
 package com.advertisementproject.zuulgateway.api.exceptions;
 
+import com.advertisementproject.zuulgateway.security.Utils.ServletResponseUtility;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -12,9 +11,14 @@ public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
-                         AuthenticationException authException) throws IOException, ServletException {
+                         AuthenticationException authException) throws IOException {
 
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getLocalizedMessage());
+        ServletResponseUtility.sendResponse(
+                response,
+                401,
+                ServletResponseUtility.toResponseMessage(
+                        authException.getLocalizedMessage(),
+                        401));
 
     }
 }

--- a/zuulgateway/src/main/java/com/advertisementproject/zuulgateway/security/configuration/WebSecurityConfiguration.java
+++ b/zuulgateway/src/main/java/com/advertisementproject/zuulgateway/security/configuration/WebSecurityConfiguration.java
@@ -37,9 +37,10 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authenticated()
                 .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                .exceptionHandling()
-                .authenticationEntryPoint(new RestAuthenticationEntryPoint())
+                //Might be necessary, but it seems like it doesn't get triggered. We may want to refactor our structure later
+//                .and()
+//                .exceptionHandling()
+//                .authenticationEntryPoint(new RestAuthenticationEntryPoint())
                 .and()
                 .addFilter(jwtUsernameAndPasswordAuthenticationFilter())
                 .addFilterBefore(new JwtRequestFilter(jwtUtils, userDetailsService), JwtUsernameAndPasswordAuthenticationFilter.class)

--- a/zuulgateway/src/main/java/com/advertisementproject/zuulgateway/security/filters/JwtUsernameAndPasswordAuthenticationFilter.java
+++ b/zuulgateway/src/main/java/com/advertisementproject/zuulgateway/security/filters/JwtUsernameAndPasswordAuthenticationFilter.java
@@ -17,6 +17,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static com.advertisementproject.zuulgateway.security.Utils.ServletResponseUtility.sendResponse;
+import static com.advertisementproject.zuulgateway.security.Utils.ServletResponseUtility.toResponseMessage;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
@@ -58,7 +59,7 @@ public class JwtUsernameAndPasswordAuthenticationFilter extends UsernamePassword
                                               HttpServletResponse response,
                                               AuthenticationException failed) throws IOException {
 
-        sendResponse(response, UNAUTHORIZED.value(), failed.getMessage());
+        sendResponse(response, UNAUTHORIZED.value(), toResponseMessage(failed.getMessage(), 401));
     }
 
 }


### PR DESCRIPTION
Made sure error messages appear in JSON format instead of string by using toResponseMessage:
```
@Override
    protected void unsuccessfulAuthentication(HttpServletRequest request,
                                              HttpServletResponse response,
                                              AuthenticationException failed) throws IOException {

        sendResponse(response, UNAUTHORIZED.value(), toResponseMessage(failed.getMessage(), 401));
    }
```

Disabled RestAuthenticationEntryPoint for now by commenting it out in WebSecurityConfiguration:
```
//                .and()
//                .exceptionHandling()
//                .authenticationEntryPoint(new RestAuthenticationEntryPoint())
```
